### PR TITLE
Fix issue: delayed service will not be restarted if swss crashes

### DIFF
--- a/scripts/featured
+++ b/scripts/featured
@@ -166,7 +166,7 @@ class FeatureHandler(object):
     def port_listener(self, key, op, data):
         if not key:
             return 
-        if op == 'SET' and key == 'PortInitDone' and not self.is_delayed_enabled:
+        if op == 'SET' and key == 'PortInitDone':
             syslog.syslog(syslog.LOG_INFO, "Updating delayed features after port initialization")
             self.enable_delayed_services()
 


### PR DESCRIPTION
**What I did**

Delayed services are counting on featured to start them when system reaches PORT INIT DONE. However, there is an extra flag check "self.is_delayed_enabled" in `port_listener`. It means that the delayed service will not be restarted if swss crashes. The PR is a fix of the issue.

**How I did**

Remove the extra flag check "self.is_delayed_enabled" in `port_listener`

**How I verified**

Manual test done, passed.